### PR TITLE
fix bug in nbdev workflow

### DIFF
--- a/.github/workflows/nbdev.yaml
+++ b/.github/workflows/nbdev.yaml
@@ -66,7 +66,7 @@ jobs:
         IMAGE_NAME="fastdotai/nbdev-dev"
         echo "current directory: ${PWD}"
         echo "::set-env name=IMAGE_NAME::${IMAGE_NAME}" 
-        repo2docker --image-name "${IMAGE_NAME}:latest" --editable --push --no-run --user-id 1000 ${PWD}
+        repo2docker --image-name "${IMAGE_NAME}:latest" --editable --push --user-id 1000 ${PWD}  echo "dev build completed"
 
     - name: push tags
       run: |


### PR DESCRIPTION
With an editable install, you have to supply a command other than running the notebook to allow the container to exit, because the container is run in the process of mounting the files for the editable install by repo2docker.  

Tested this workaround and it works