### PR TITLE
Make fastai conda environment omnipresent

### DIFF
--- a/fastai2-build/Dockerfile
+++ b/fastai2-build/Dockerfile
@@ -44,7 +44,7 @@ COPY ./docker/fastai2-build/conda_init.txt /home/conda_init.txt
 RUN cat /home/conda_init.txt >> ~/.bashrc
 COPY --chown=$DOCKER_USER ./docker/fastai2-build/entrypoint.sh /home/entrypoint.sh
 COPY --chown=$DOCKER_USER ./docker/fastai2-build/run_jupyter.sh /home/run_jupyter.sh
-ENV PATH="/miniconda3/bin:${PATH}"
+ENV PATH="/miniconda3/envs/fastai2/bin/python:${PATH}"
 RUN chmod u+x entrypoint.sh
 RUN chmod u+x run_jupyter.sh
 

--- a/fastai2-build/entrypoint.sh
+++ b/fastai2-build/entrypoint.sh
@@ -1,4 +1,4 @@
-export PATH=/miniconda3/bin:${PATH}
+export PATH=/miniconda3/envs/fastai2/bin/python:${PATH}
 source activate fastai2
 
 exec "$@"


### PR DESCRIPTION
The problem this PR is solving is the following:

- All commands run in the docker container should execute against the fastai conda environment, regardless if the user:

1. Passes in command in a non-interactive way `docker run fastdotai/fastai2 some command`. This is currently enabled through a special bash script that spoofs the entrypoint to run in the right conda env.
2. Starts an interactive shell in the container `docker run -it fastdotai/fastai2 bash` 
3. Attaches a shell to an already running container `docker exec -it <containerid> bash` 

Before, scenarios 2 & 3 required some manual intervention like conda activate etc. to bring switch into the right environment.  This hard codes the correct python path which fixes this error.  

cc: @jph00 
