### PR TITLE
resolve nbconvert conflict w/ nbdev

### DIFF
--- a/fastai-build/Dockerfile
+++ b/fastai-build/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install albumentations \
     jupyter \
     kornia \
     matplotlib \
+    "nbconvert<6"\
     nbdev \
     neptune-cli \
     opencv-python \


### PR DESCRIPTION
Current version has an error on line 7 of the Dockerfile `RUN pip .. `

`ERROR: nbdev 1.1.2 has requirement nbconvert<6, but you'll have nbconvert 6.0.7 which is incompatible.`

However, nbdev and nbconvert seem to both install and are working (at least for very surface level tests).

This PR adds a constraint on the version of nbconvert such that the pip run completes without errors; the nbcovert version installed is `nbconvert-5.6.1`.

