### PR TITLE
Update download_testdata.py

### DIFF
--- a/fastai/tmp_scripts/download_testdata.py
+++ b/fastai/tmp_scripts/download_testdata.py
@@ -2,11 +2,11 @@
 Downloads test data used in CI
 """
 from IPython import get_ipython
-from fastai.data.external import download_data, URLs
+from fastai.data.external import untar_data, URLs
 from fastai.torch_core import parallel
 import pickle
 
 urls = ['ADULT_SAMPLE','BIWI_SAMPLE','CAMVID_TINY','CIFAR','COCO_TINY','IMDB','IMDB_SAMPLE',
         'ML_SAMPLE','MNIST','MNIST_SAMPLE','MNIST_TINY','PETS']
 url_list = [URLs.__dict__[k] for k in urls]
-files = [(print(f'Downloading {u}'), download_data(u)) for u in url_list]
+files = [(print(f'Downloading {u}'), untar_data(u)) for u in url_list]


### PR DESCRIPTION
@jph00 update the script that downloads test data to use the new function `untar_data`.  I think this will fix CI 